### PR TITLE
Add assertions to parse() method

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -58,4 +58,5 @@ shadowJar {
 
 run{
     standardInput = System.in
+    enableAssertions = true
 }

--- a/src/main/java/duke/Parser.java
+++ b/src/main/java/duke/Parser.java
@@ -38,6 +38,7 @@ public class Parser {
     public static Command parse(String inputCommand) throws DukeException {
         try {
             String[] splitInputCommand = inputCommand.trim().split(" ", 2);
+            assert splitInputCommand.length > 0 : "Input command cannot be empty!";
             CommandTag ct = CommandTag.valueOf(splitInputCommand[0].toUpperCase());
             switch (ct) {
             case BYE:


### PR DESCRIPTION
This assertion ensures that the user input commands will never result
in an empty array when splitting the input command.